### PR TITLE
Switch to npm assets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /.idea/
+node_modules/
+public/vendor/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,6 @@
+VENDOR_DIR = public/vendor/ol
+
+assets:
+	mkdir -p $(VENDOR_DIR)
+	cp node_modules/ol/ol.css $(VENDOR_DIR)/
+	cp node_modules/ol/dist/ol.js $(VENDOR_DIR)/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,13 @@
 # geochron
 GeoChron – determine your location in time on Earth.
+
+## Development
+
+Install dependencies and build vendor assets:
+
+```bash
+npm install
+npm run build
+```
+
+This copies required files from `node_modules` to `public/vendor`.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "geochron",
+  "version": "1.0.0",
+  "description": "GeoChron – determine your location in time on Earth.",
+  "main": "index.js",
+  "scripts": {
+    "build": "make assets",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "ol": "7.3.0"
+  }
+}

--- a/public/index.html
+++ b/public/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <title>GeoChron Tool – Full Features</title>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/ol@7.3.0/ol.css">
+  <link rel="stylesheet" href="vendor/ol/ol.css">
   <style>
     html, body, #map {
       margin: 0;
@@ -49,7 +49,7 @@
   <div class="coord-display" id="coordDisplay">Lon: –, Lat: –, Elev: –</div>
   <div id="map"></div>
 
-  <script src="https://cdn.jsdelivr.net/npm/ol@7.3.0/dist/ol.js"></script>
+  <script src="vendor/ol/ol.js"></script>
   <script>
     const osmLayer = new ol.layer.Tile({ source: new ol.source.OSM(), visible: true });
     const topoLayer = new ol.layer.Tile({


### PR DESCRIPTION
## Summary
- configure npm and local build script
- copy OpenLayers assets via Makefile
- load assets from `public/vendor`
- document the build process

## Testing
- `npm run build` *(fails: cannot find `node_modules/ol/ol.css`)*
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686f60b442a8832e9c5a402ad88567d6