### PR TITLE
Add identify request on map click

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # geochron
 GeoChron – determine your location in time on Earth.
 
+Clicking on the map places a marker and performs an ArcGIS **identify** request
+against the visible geology layer (GÜK250). Returned records are shown in a
+modal dialog.
+
 ## Development
 
 Install dependencies and build vendor assets:

--- a/public/index.html
+++ b/public/index.html
@@ -32,6 +32,35 @@
       font-size: 13px;
       z-index: 1001;
     }
+    .modal {
+      position: fixed;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      background: rgba(0,0,0,0.6);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      z-index: 2000;
+    }
+    .modal.hidden { display: none; }
+    .modal-content {
+      position: relative;
+      background: #fff;
+      padding: 20px;
+      max-height: 80%;
+      overflow-y: auto;
+      min-width: 260px;
+      font-family: sans-serif;
+    }
+    .modal-close {
+      position: absolute;
+      top: 5px;
+      right: 10px;
+      cursor: pointer;
+      font-weight: bold;
+    }
   </style>
 </head>
 <body>
@@ -58,6 +87,12 @@
   </div>
   <div class="coord-display" id="coordDisplay">Lon: –, Lat: –, Elev: –</div>
   <div id="map"></div>
+  <div id="identifyModal" class="modal hidden">
+    <div class="modal-content">
+      <span id="identifyClose" class="modal-close">&times;</span>
+      <div id="identifyResults"></div>
+    </div>
+  </div>
 
   <script src="vendor/ol/ol.js"></script>
   <script>
@@ -140,6 +175,53 @@
       }
     }
 
+    function identifyPoint(lon, lat) {
+      const pt3857 = ol.proj.transform([lon, lat], 'EPSG:4326', 'EPSG:3857');
+      const size = map.getSize();
+      const extent = map.getView().calculateExtent(size);
+      const params = new URLSearchParams({
+        f: 'json',
+        tolerance: 3,
+        returnGeometry: false,
+        imageDisplay: `${size[0]},${size[1]},96`,
+        geometry: `${pt3857[0]},${pt3857[1]}`,
+        geometryType: 'esriGeometryPoint',
+        sr: 3857,
+        layers: 'all',
+        mapExtent: extent.join(',')
+      });
+      fetch('https://services.bgr.de/arcgis/rest/services/geologie/guek250/MapServer/identify?' + params.toString())
+        .then(r => r.json())
+        .then(showIdentifyResults)
+        .catch(() => showIdentifyResults(null));
+    }
+
+    function showIdentifyResults(data) {
+      const modal = document.getElementById('identifyModal');
+      const resDiv = document.getElementById('identifyResults');
+      resDiv.innerHTML = '';
+      if (!data || !data.results || data.results.length === 0) {
+        resDiv.textContent = 'No results';
+      } else {
+        const ul = document.createElement('ul');
+        data.results.forEach(item => {
+          const li = document.createElement('li');
+          let html = `<strong>${item.layerName}</strong> (ID ${item.layerId})`;
+          if (item.attributes) {
+            const lines = [];
+            ['value', 'text', 'name'].forEach(k => {
+              if (item.attributes[k]) lines.push(`${k}: ${item.attributes[k]}`);
+            });
+            if (lines.length) html += '<br>' + lines.join('<br>');
+          }
+          li.innerHTML = html;
+          ul.appendChild(li);
+        });
+        resDiv.appendChild(ul);
+      }
+      modal.classList.remove('hidden');
+    }
+
     function fetchElevation(lon, lat) {
       fetch(`proxy.php?lat=${lat}&lon=${lon}`)
         .then(response => response.json())
@@ -178,6 +260,7 @@
     map.on('click', function (evt) {
       const coords = ol.proj.toLonLat(evt.coordinate);
       setMarker(coords[0], coords[1], { center: true });
+      identifyPoint(coords[0], coords[1]);
     });
 
     function parseCoords(latStr, lonStr) {
@@ -222,6 +305,15 @@
             list.appendChild(li);
           });
         });
+    });
+
+    document.getElementById('identifyClose').addEventListener('click', () => {
+      document.getElementById('identifyModal').classList.add('hidden');
+    });
+    document.getElementById('identifyModal').addEventListener('click', (e) => {
+      if (e.target === document.getElementById('identifyModal')) {
+        document.getElementById('identifyModal').classList.add('hidden');
+      }
     });
 
     window.addEventListener('load', () => {


### PR DESCRIPTION
## Summary
- show identify results in a new modal
- perform identify request when the map is clicked

## Testing
- `npm run build` *(fails: cp: cannot stat 'node_modules/ol/ol.css')*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/ol)*
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687219edfe5c832e81a0892fc3c0605a