### PR TITLE
Improve map interaction and default zoom

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -247,7 +247,8 @@
         navigator.geolocation.getCurrentPosition(function (position) {
           const lon = position.coords.longitude;
           const lat = position.coords.latitude;
-          setMarker(lon, lat, { center: true, zoom: 14 });
+          document.getElementById('identifyModal').classList.add('hidden');
+          setMarker(lon, lat, { center: true, zoom: 10 });
         }, function (err) {
           alert('Geolocation failed: ' + err.message);
         });
@@ -259,7 +260,8 @@
     // Manual click
     map.on('click', function (evt) {
       const coords = ol.proj.toLonLat(evt.coordinate);
-      setMarker(coords[0], coords[1], { center: true });
+      document.getElementById('identifyModal').classList.add('hidden');
+      setMarker(coords[0], coords[1], { center: false });
       identifyPoint(coords[0], coords[1]);
     });
 
@@ -283,7 +285,8 @@
         alert('Invalid coordinates');
         return;
       }
-      setMarker(c.lon, c.lat, { center: true, zoom: 14 });
+      document.getElementById('identifyModal').classList.add('hidden');
+      setMarker(c.lon, c.lat, { center: true, zoom: 10 });
     });
 
     document.getElementById('searchBtn').addEventListener('click', function () {
@@ -299,7 +302,8 @@
             li.textContent = item.display_name;
             li.style.cursor = 'pointer';
             li.addEventListener('click', () => {
-              setMarker(parseFloat(item.lon), parseFloat(item.lat), { center: true, zoom: 14 });
+              document.getElementById('identifyModal').classList.add('hidden');
+              setMarker(parseFloat(item.lon), parseFloat(item.lat), { center: true, zoom: 10 });
               list.innerHTML = '';
             });
             list.appendChild(li);


### PR DESCRIPTION
## Summary
- stop centering the map on click
- hide identify panel on map interaction and searches
- lower default zoom level when placing a marker via GPS, coordinate input or search

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68724bed6bd0832eb4e93836f600207a